### PR TITLE
Hardcode ASG size to 1/2

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ module "teleport_github_app_secret" {
   ]
 }
 ```
-
 ## Requirements
 
 | Name | Version |
@@ -103,10 +102,9 @@ module "teleport_github_app_secret" {
 | [aws_dynamodb_table.teleport](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
 | [aws_iam_policy.RDSDiscovery](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.TeleportEC2Discovery](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.TeleportEC2DiscoveryBoundary](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.TeleportIdentitySecurity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.dynamodb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_key_pair.mediapc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/key_pair) | resource |
 | [aws_key_pair.teleport](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/key_pair) | resource |
 | [aws_launch_template.teleport](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
 | [aws_lb_listener.ssl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
@@ -129,7 +127,7 @@ module "teleport_github_app_secret" {
 | [aws_iam_policy.ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
 | [aws_iam_policy_document.RDSDiscovery](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.TeleportEC2Discovery](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.TeleportEC2DiscoveryBoundary](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.TeleportIdentitySecurity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.default_permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.dynamodb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -143,8 +141,6 @@ module "teleport_github_app_secret" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_asg_max_size"></a> [asg\_max\_size](#input\_asg\_max\_size) | Maximum number of instances in ASG | `number` | `null` | no |
-| <a name="input_asg_min_size"></a> [asg\_min\_size](#input\_asg\_min\_size) | Minimum number of instances in ASG | `number` | `null` | no |
 | <a name="input_backend_subnet_ids"></a> [backend\_subnet\_ids](#input\_backend\_subnet\_ids) | Subnets to use for the Teleport server | `list(string)` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Name of environment. | `string` | n/a | yes |
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | Allow deleting data from S3 bucket and DynamoDB table. | `bool` | `false` | no |

--- a/asg.tf
+++ b/asg.tf
@@ -100,8 +100,8 @@ locals {
 
 resource "aws_autoscaling_group" "teleport" {
   name                      = local.asg_name
-  min_size                  = var.asg_min_size == null ? length(var.backend_subnet_ids) : var.asg_min_size
-  max_size                  = var.asg_max_size == null ? length(var.backend_subnet_ids) + 1 : var.asg_max_size
+  min_size                  = 1
+  max_size                  = 2
   vpc_zone_identifier       = var.backend_subnet_ids
   health_check_type         = "ELB"
   health_check_grace_period = 900
@@ -134,7 +134,8 @@ resource "aws_autoscaling_group" "teleport" {
   instance_refresh {
     strategy = "Rolling"
     preferences {
-      min_healthy_percentage = 100
+      min_healthy_percentage = 90
+      max_healthy_percentage = 100
     }
   }
   tag {

--- a/variables.tf
+++ b/variables.tf
@@ -1,15 +1,3 @@
-variable "asg_min_size" {
-  description = "Minimum number of instances in ASG"
-  type        = number
-  default     = null
-}
-
-variable "asg_max_size" {
-  description = "Maximum number of instances in ASG"
-  type        = number
-  default     = null
-}
-
 variable "backend_subnet_ids" {
   description = "Subnets to use for the Teleport server"
   type        = list(string)


### PR DESCRIPTION
According to https://goteleport.com/docs/reference/backends/#dynamodb
there should be not more than 2 auth service instances. Otherwise,
instance refresh may fails.
Setting min size to 1 and max size to 2.
Adjust instance refresh policy accordingly.
