### PR TITLE
Lower minimum number of instances to 1

### DIFF
--- a/asg.tf
+++ b/asg.tf
@@ -134,7 +134,7 @@ resource "aws_autoscaling_group" "teleport" {
   instance_refresh {
     strategy = "Rolling"
     preferences {
-      min_healthy_percentage = 90
+      min_healthy_percentage = 50
       max_healthy_percentage = 100
     }
   }


### PR DESCRIPTION
To ensure a successful instance refresh, we need to keep 1 instance online.
If the min persentage goves over 50%, the instance refresh can't complete successfully.
